### PR TITLE
build(version): expose runtime version from importlib.metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,6 @@ upload_to_pypi = true
 branch = "main"
 repository_platform = "github"
 version_source = "commit"
+# Ensure the runtime version is sourced from the installed distribution via importlib.metadata
+# (see src/dictdb/__init__.py). Semantic-release will continue to bump the value in pyproject.toml.
 changelog_file = "CHANGELOG.md"

--- a/src/dictdb/__init__.py
+++ b/src/dictdb/__init__.py
@@ -1,9 +1,19 @@
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
 from .backup import BackupManager
 from .condition import Condition
 from .table import Table
 from .database import DictDB
 from .exceptions import DuplicateKeyError, RecordNotFoundError, SchemaValidationError
 from .logging import logger, configure_logging
+
+# Expose the installed package version dynamically to avoid duplication.
+try:
+    __version__ = _pkg_version("dictdb")
+except (
+    PackageNotFoundError
+):  # pragma: no cover - during editable installs or local runs
+    __version__ = "0.0.0"
 
 __all__ = [
     "DictDB",
@@ -15,4 +25,5 @@ __all__ = [
     "logger",
     "configure_logging",
     "BackupManager",
+    "__version__",
 ]


### PR DESCRIPTION
- Add dynamic __version__ in src/dictdb/__init__.py using importlib.metadata.version("dictdb") with a safe fallback for editable installs.
- Keep semantic-release bumping project.version in pyproject.toml; add note to document the relationship.