### PR TITLE
feat(table): add columns(), count()/size(), len(), and introspection helpers

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -56,9 +56,6 @@ This roadmap focuses on concrete improvements and extensions derived from the cu
 - Optional fast JSON backend behind a feature flag; micro‑opt index paths.
 - Acceptance: reduced peak memory during save; no API changes.
 
-12) API Polish & Types
-- Add `Table.columns()`, `Table.size()`, and introspection helpers; tighten types (TypedDict/Protocol) and reduce `Any`/`cast`.
-- Acceptance: `mypy src` passes in strict mode; improved IDE hints.
 
 ## Nice‑To‑Haves
 - Generated API docs (pdoc/Sphinx) with examples and tutorial notebooks.

--- a/src/dictdb/table.py
+++ b/src/dictdb/table.py
@@ -432,3 +432,75 @@ class Table:
         :rtype: list
         """
         return [record.copy() for record in self.records.values()]
+
+    def columns(self) -> List[str]:
+        """
+        Returns the list of column names for this table.
+
+        If a schema is defined, columns are derived from it. Otherwise, the
+        union of keys across all existing records is returned. The order is
+        deterministic (sorted) when derived from records.
+
+        :return: List of column names.
+        """
+        if self.schema is not None:
+            return list(self.schema.keys())
+        # Derive from data when schema is absent
+        cols: set[str] = set()
+        for rec in self.records.values():
+            cols.update(rec.keys())
+        return sorted(cols)
+
+    def size(self) -> int:
+        """
+        Returns the number of records stored in the table.
+
+        :return: Count of records.
+        """
+        return self.count()
+
+    def count(self) -> int:
+        """
+        Returns the number of records stored in the table.
+
+        Preferred over size(); size() remains as an alias.
+
+        :return: Count of records.
+        """
+        return len(self.records)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return self.count()
+
+    def indexed_fields(self) -> List[str]:
+        """
+        Returns the list of fields that currently have an index.
+
+        :return: List of indexed field names.
+        """
+        return list(self.indexes.keys())
+
+    def has_index(self, field: str) -> bool:
+        """
+        Indicates whether an index exists for the given field.
+
+        :param field: Field name to check.
+        :return: True if an index exists for the field.
+        """
+        return field in self.indexes
+
+    def schema_fields(self) -> List[str]:
+        """
+        Returns the list of fields defined in the schema, or an empty list if no schema.
+
+        :return: Schema field names.
+        """
+        return list(self.schema.keys()) if self.schema is not None else []
+
+    def primary_key_name(self) -> str:
+        """
+        Returns the name of the primary key field for this table.
+
+        :return: Primary key field name.
+        """
+        return self.primary_key

--- a/tests/test_table_introspection.py
+++ b/tests/test_table_introspection.py
@@ -1,0 +1,44 @@
+from typing import Set
+
+from dictdb import Table
+
+
+def test_columns_with_schema() -> None:
+    schema = {"id": int, "name": str, "age": int}
+    table = Table("people", primary_key="id", schema=schema)
+    # With a schema, columns are derived from the schema keys
+    cols = set(table.columns())
+    assert cols == set(schema.keys())
+
+
+def test_columns_without_schema(table: Table) -> None:
+    # No schema: columns are derived from records; expect union of keys
+    cols: Set[str] = set(table.columns())
+    assert cols == {"id", "name", "age"}
+
+
+def test_count_records_and_len(table: Table) -> None:
+    assert table.count() == 2
+    assert len(table) == 2
+    table.insert({"id": 3, "name": "Charlie", "age": 40})
+    assert table.count() == 3
+    assert len(table) == 3
+
+
+def test_indexed_fields_and_has_index(indexed_table: Table) -> None:
+    indexed = set(indexed_table.indexed_fields())
+    assert indexed == {"age"}
+    assert indexed_table.has_index("age") is True
+    assert indexed_table.has_index("name") is False
+
+
+def test_schema_fields_and_primary_key() -> None:
+    schema = {"user_id": int, "name": str}
+    t = Table("users", primary_key="user_id", schema=schema)
+    assert set(t.schema_fields()) == set(schema.keys())
+    assert t.primary_key_name() == "user_id"
+
+
+def test_schema_fields_no_schema(table: Table) -> None:
+    # When schema is not provided, schema_fields() should be empty
+    assert table.schema_fields() == []


### PR DESCRIPTION
- Add Table.columns(), count() (alias size()), len(), indexed_fields(), has_index(), schema_fields(), primary_key_name()
- Keep size() as alias to count() for compatibility
- New tests: tests/test_table_introspection.py covering new helpers
- Docs: remove completed roadmap item 12

Tests: 54 passed; mypy --strict clean